### PR TITLE
Increase Java heap size before calling rJava

### DIFF
--- a/lib/kumquat/engine.rb
+++ b/lib/kumquat/engine.rb
@@ -61,6 +61,7 @@ module Kumquat
 
         r_commands = [
           "setwd('#{tmp_dir}');",
+          "options(java.parameters = '-Xmx4g');",
           "#{r_libraries}",
           redshift_connection(tmp_dir),
           "knit2html('#{@file}', options=#{knitr_options});"


### PR DESCRIPTION
The `redshift` library depends on `rJava`, which sets a limit on the amount of memory available.

Some queries that return a lot of results will fail with the error:

`java.lang.OutOfMemoryError: Java heap space`

This PR increases the Java heap size prior to calling `redshift`.

More info on rJava memory constraints here:
http://www.bramschoenmakers.nl/en/node/726